### PR TITLE
feat: add erc20_transfers to dataset

### DIFF
--- a/examples/datasets/eth/erc20_transfers.py
+++ b/examples/datasets/eth/erc20_transfers.py
@@ -15,7 +15,7 @@ from cherry_etl.pipeline import run_pipeline
 load_dotenv()
 
 logging.basicConfig(level=os.environ.get("LOGLEVEL", "INFO").upper())
-logger = logging.getLogger("examples.eth.all_contracts")
+logger = logging.getLogger("examples.eth.erc20_transfers")
 
 
 PROVIDER_URLS = {
@@ -46,10 +46,10 @@ async def sync_data(
     )
 
     # Create the pipeline using the all_contracts dataset
-    pipeline = datasets.evm.all_contracts(provider, writer, from_block, to_block)
+    pipeline = datasets.evm.erc20_transfers(provider, writer, from_block, to_block)
 
     # Run the pipeline
-    await run_pipeline(pipeline_name="all_contracts", pipeline=pipeline)
+    await run_pipeline(pipeline_name="erc20_transfers", pipeline=pipeline)
 
 
 async def main(
@@ -66,12 +66,12 @@ async def main(
     )
 
     # Optional: read result to show
-    data = connection.sql("SELECT * FROM contracts LIMIT 20")
+    data = connection.sql("SELECT * FROM erc20_transfers LIMIT 20")
     logger.info(data)
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="All contracts ever created")
+    parser = argparse.ArgumentParser(description="ERC20 transfers")
     parser.add_argument(
         "--provider",
         choices=["sqd", "hypersync"],

--- a/src/cherry_etl/datasets/evm/__init__.py
+++ b/src/cherry_etl/datasets/evm/__init__.py
@@ -1,5 +1,6 @@
 from .address_appearances import make_pipeline as address_appearances
 from .all_contracts import make_pipeline as all_contracts
 from .blocks import make_pipeline as blocks
+from .erc20_transfers import make_pipeline as erc20_transfers
 
-__all__ = ["address_appearances", "all_contracts", "blocks"]
+__all__ = ["address_appearances", "all_contracts", "blocks", "erc20_transfers"]

--- a/src/cherry_etl/datasets/evm/erc20_transfers.py
+++ b/src/cherry_etl/datasets/evm/erc20_transfers.py
@@ -1,0 +1,77 @@
+import logging
+from typing import Any, Dict, Optional
+
+import polars as pl
+import pyarrow as pa
+from cherry_core import ingest
+
+from cherry_etl import config as cc
+
+logger = logging.getLogger(__name__)
+
+TABLE_NAME = "erc20_transfers"
+
+
+def process_data(data: Dict[str, pl.DataFrame], _: Any) -> Dict[str, pl.DataFrame]:
+    logger.info(data.keys())
+    out = data["transactions"]
+
+    return {"erc20_transfers": out}
+
+
+def make_pipeline(
+    provider: ingest.ProviderConfig,
+    writer: cc.Writer,
+    from_block: int = 0,
+    to_block: Optional[int] = None,
+) -> cc.Pipeline:
+    if to_block is not None and from_block > to_block:
+        raise Exception("block range is invalid")
+
+    query = ingest.Query(
+        kind=ingest.QueryKind.EVM,
+        params=ingest.evm.Query(
+            from_block=from_block,
+            to_block=to_block,
+            include_all_blocks=True,
+            transactions=[ingest.evm.TransactionRequest()],
+            logs=[
+                ingest.evm.LogRequest(
+                    topic0=[
+                        "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+                    ]
+                )
+            ],
+            fields=ingest.evm.Fields(
+                transaction=ingest.evm.TransactionFields(
+                    hash=True, from_=True, value=True
+                ),
+            ),
+        ),
+    )
+
+    return cc.Pipeline(
+        provider=provider,
+        query=query,
+        writer=writer,
+        steps=[
+            cc.Step(
+                name="i256_to_i128",
+                kind=cc.StepKind.CAST_BY_TYPE,
+                config=cc.CastByTypeConfig(
+                    from_type=pa.decimal256(76, 0),
+                    to_type=pa.decimal128(38, 0),
+                ),
+            ),
+            cc.Step(
+                kind=cc.StepKind.CUSTOM,
+                config=cc.CustomStepConfig(
+                    runner=process_data,
+                ),
+            ),
+            cc.Step(
+                kind=cc.StepKind.HEX_ENCODE,
+                config=cc.HexEncodeConfig(),
+            ),
+        ],
+    )


### PR DESCRIPTION
This PR add `erc20_transfers` dataset. Easily track all ERC20 token transfers on any EVM chain.